### PR TITLE
Fix wave directive not working

### DIFF
--- a/resources/js/directive/waves/waves.js
+++ b/resources/js/directive/waves/waves.js
@@ -69,7 +69,7 @@ export default {
     el.addEventListener('click', handleClick(el, binding), false);
   },
   update(el, binding) {
-    el.removeEventListener('click', el[context].removeHandle, false);
+    el.removeEventListener('click', el[context].removeHandle, true);
     el.addEventListener('click', handleClick(el, binding), false);
   },
   unbind(el) {


### PR DESCRIPTION
- Fix issue: #65 .
- Set `useCapture = True` in the event listener method.

The standard DOM Events describes 3 phases of event propagation:
1. Capturing phase: the event goes down to the element. 
2. Target phase: the event reached the target element.
3. Bubbling phase: the event bubbles up from the element.

The capturing phase is rarely used. Normally we ignore it. So our handler will only be called during the event bubbling phase.

In this case, we must remove the event handler from the capturing phase. Then, in the bubbling phase, we add click event again.
