### PR TITLE
[FIX] Allow user to update self profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,14 +56,14 @@ npm install
 npm run dev # or npm run watch
 
 # Build on production
-npm  run production
+npm run production
 ```
 
 #### Docker
 ```sh
 docker-compose up -d
 ```
-Run database migration and seed within Docker container
+Build static files within Laravel container with npm
 ```sh
 # Get laravel docker container ID from containers list
 docker ps
@@ -71,7 +71,7 @@ docker ps
 docker exec -it <container ID> npm run dev # or npm run watch
 # Where <container ID> is the "laravel" container name, ex: docker_laravel_1
 ```
-Open http://localhost:8000 (laravel container port) to access Laravue
+Open http://localhost:8000 (laravel container port declared in `docker-compose.yml`) to access Laravue
 
 ## Running the tests
 * Tests system is under development

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -18,6 +18,7 @@ use App\Laravue\Models\User;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\ResourceCollection;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Hash;
 use Validator;
 
@@ -116,6 +117,14 @@ class UserController extends Controller
         }
         if ($user->isAdmin()) {
             return response()->json(['error' => 'Admin can not be modified'], 403);
+        }
+
+        $currentUser = Auth::user();
+        if (!$currentUser->isAdmin()
+            && $currentUser->id !== $user->id
+            && !$currentUser->hasPermission(\App\Laravue\Acl::PERMISSION_USER_MANAGE)
+        ) {
+            return response()->json(['error' => 'Permission denied'], 403);
         }
 
         $validator = Validator::make($request->all(), $this->getValidationRules(false));

--- a/app/Laravue/Models/User.php
+++ b/app/Laravue/Models/User.php
@@ -72,11 +72,26 @@ class User extends Authenticatable
     }
 
     /**
+     * Check if user has a permission
+     * @param String
+     * @return bool
+     */
+    public function hasPermission($permission): bool
+    {
+        foreach ($this->roles as $role) {
+            if (in_array($permission, $role->permissions->toArray())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
      * @return bool
      */
     public function isAdmin(): bool
     {
-        foreach ($this->roles  as $role) {
+        foreach ($this->roles as $role) {
             if ($role->isAdmin()) {
                 return true;
             }

--- a/public/.gitignore
+++ b/public/.gitignore
@@ -1,0 +1,1 @@
+mix-manifest.json

--- a/public/mix-manifest.json
+++ b/public/mix-manifest.json
@@ -1,6 +1,0 @@
-{
-    "/js/app.js": "/js/app.js?id=cb7340b2f2befa0620da",
-    "/css/app.css": "/css/app.css?id=65502353c410f352ded4",
-    "/js/manifest.js": "/js/manifest.js?id=3c768977c2574a34506e",
-    "/js/vendor.js": "/js/vendor.js?id=38c0bff14a72050bdfad"
-}

--- a/resources/js/components/HeaderSearch/index.vue
+++ b/resources/js/components/HeaderSearch/index.vue
@@ -35,7 +35,7 @@ export default {
   },
   computed: {
     routes() {
-      return this.$store.getters.permission_routes;
+      return this.$store.getters.permissionRoutes;
     },
     lang() {
       return this.$store.getters.language;

--- a/resources/js/layout/components/Navbar.vue
+++ b/resources/js/layout/components/Navbar.vue
@@ -28,7 +28,7 @@
               {{ $t('navbar.dashboard') }}
             </el-dropdown-item>
           </router-link>
-          <router-link v-show="userId !== null" :to="`/administrator/users/edit/${userId}`">
+          <router-link v-show="userId !== null" :to="`/profile/edit`">
             <el-dropdown-item>
               {{ $t('navbar.profile') }}
             </el-dropdown-item>

--- a/resources/js/router/index.js
+++ b/resources/js/router/index.js
@@ -106,6 +106,19 @@ export const constantRoutes = [
     ],
   },
   {
+    path: '/profile',
+    component: Layout,
+    redirect: '/profile/edit',
+    children: [
+      {
+        path: 'edit',
+        component: () => import('@/views/users/SelfProfile'),
+        name: 'SelfProfile',
+        meta: { title: 'userProfile', icon: 'user', noCache: true },
+      },
+    ],
+  },
+  {
     path: '/guide',
     component: Layout,
     redirect: '/guide/index',

--- a/resources/js/router/modules/admin.js
+++ b/resources/js/router/modules/admin.js
@@ -16,7 +16,7 @@ const adminRoutes = {
     /** User managements */
     {
       path: 'users/edit/:id(\\d+)',
-      component: () => import('@/views/users/Profile'),
+      component: () => import('@/views/users/UserProfile'),
       name: 'UserProfile',
       meta: { title: 'userProfile', noCache: true, permissions: ['manage user'] },
       hidden: true,

--- a/resources/js/store/getters.js
+++ b/resources/js/store/getters.js
@@ -12,7 +12,7 @@ const getters = {
   introduction: state => state.user.introduction,
   roles: state => state.user.roles,
   permissions: state => state.user.permissions,
-  permission_routes: state => state.permission.routes,
+  permissionRoutes: state => state.permission.routes,
   addRoutes: state => state.permission.addRoutes,
 };
 export default getters;

--- a/resources/js/views/articles/components/ArticleDetail.vue
+++ b/resources/js/views/articles/components/ArticleDetail.vue
@@ -243,7 +243,6 @@ export default {
     },
     submitForm() {
       this.postForm.display_time = parseInt(this.display_time / 1000);
-      console.log(this.postForm);
       this.$refs.postForm.validate(valid => {
         if (valid) {
           this.loading = true;

--- a/resources/js/views/users/SelfProfile.vue
+++ b/resources/js/views/users/SelfProfile.vue
@@ -1,0 +1,43 @@
+<template>
+  <div class="app-container">
+    <el-form v-if="user" :model="user">
+      <el-row :gutter="20">
+        <el-col :span="6">
+          <user-card :user="user" />
+          <user-bio />
+        </el-col>
+        <el-col :span="18">
+          <user-activity :user="user" />
+        </el-col>
+      </el-row>
+    </el-form>
+  </div>
+</template>
+
+<script>
+import UserBio from './components/UserBio';
+import UserCard from './components/UserCard';
+import UserActivity from './components/UserActivity';
+
+export default {
+  name: 'SelfProfile',
+  components: { UserBio, UserCard, UserActivity },
+  data() {
+    return {
+      user: {},
+    };
+  },
+  watch: {
+    '$route': 'getUser',
+  },
+  created() {
+    this.getUser();
+  },
+  methods: {
+    async getUser() {
+      const data = await this.$store.dispatch('user/getInfo');
+      this.user = data;
+    },
+  },
+};
+</script>

--- a/resources/js/views/users/UserProfile.vue
+++ b/resources/js/views/users/UserProfile.vue
@@ -34,6 +34,11 @@ export default {
   },
   created() {
     const id = this.$route.params && this.$route.params.id;
+    const currentUserId = this.$store.getters.userId;
+    if (id === currentUserId) {
+      this.$router.push('/profile/edit');
+      return;
+    }
     this.getUser(id);
   },
   methods: {

--- a/routes/api.php
+++ b/routes/api.php
@@ -19,7 +19,10 @@ Route::post('auth/login', 'AuthController@login');
 Route::group(['middleware' => 'auth:api'], function () {
     Route::get('auth/user', 'AuthController@user');
     Route::post('auth/logout', 'AuthController@logout');
-    Route::apiResource('users', 'UserController')->middleware('permission:' . \App\Laravue\Acl::PERMISSION_USER_MANAGE);
+    Route::get('users', 'UserController@index')->middleware('permission:' . \App\Laravue\Acl::PERMISSION_USER_MANAGE);
+    Route::get('users/{user}', 'UserController@show')->middleware('permission:' . \App\Laravue\Acl::PERMISSION_USER_MANAGE);
+    Route::put('users/{user}', 'UserController@update');
+    Route::delete('users/{user}', 'UserController@destroy')->middleware('permission:' . \App\Laravue\Acl::PERMISSION_USER_MANAGE);
     Route::get('users/{user}/permissions', 'UserController@permissions')->middleware('permission:' . \App\Laravue\Acl::PERMISSION_PERMISSION_MANAGE);
     Route::put('users/{user}/permissions', 'UserController@updatePermissions')->middleware('permission:' . \App\Laravue\Acl::PERMISSION_PERMISSION_MANAGE);
     Route::apiResource('roles', 'RoleController')->middleware('permission:' . \App\Laravue\Acl::PERMISSION_PERMISSION_MANAGE);


### PR DESCRIPTION
# Issue
* https://github.com/tuandm/laravue/issues/121

# Why
* Laravue requires user manage permission to edit profile, even it's self profile

# What
* In Laravel: Add an additional API to allow user to update their own profile (check if ID of updated user is equal to current logged in user's ID).
* In Vue
  * Add an additional Vue view for updating self profile. Endpoint: `profile/edit`
  * In case user, who has user management permission, enters user edit view of administrator, redirect to self profile updating endpoint

## Minors
* Use camelCase for JS variable name instead of snake_case

## Screenshots
* User with email editor@laravue.dev has Editor role, not Administrator.
![image](https://user-images.githubusercontent.com/8892458/77229372-dccccb80-6bd0-11ea-8b62-b088b4bd9d15.png)
