### PR TITLE
Fix migrations after applying Laravel passport

### DIFF
--- a/app/Laravue/Models/Permission.php
+++ b/app/Laravue/Models/Permission.php
@@ -18,6 +18,8 @@ use Illuminate\Database\Query\Builder;
  */
 class Permission extends \Spatie\Permission\Models\Permission
 {
+    public $guard_name = 'api';
+
     /**
      * To exclude permission management from the list
      *

--- a/app/Laravue/Models/Role.php
+++ b/app/Laravue/Models/Role.php
@@ -20,6 +20,8 @@ use Spatie\Permission\Models\Permission;
  */
 class Role extends \Spatie\Permission\Models\Role
 {
+    public $guard_name = 'api';
+
     /**
      * Check whether current role is admin
      * @return bool

--- a/database/migrations/2019_04_20_130706_setup_role_permissions.php
+++ b/database/migrations/2019_04_20_130706_setup_role_permissions.php
@@ -17,8 +17,9 @@ class SetupRolePermissions extends Migration
     public function up()
     {
         foreach (Acl::roles() as $role) {
-            Role::findOrCreate($role, 'api');
+            Role::findOrCreate($role);
         }
+
         $adminRole = Role::findByName(Acl::ROLE_ADMIN);
         $managerRole = Role::findByName(Acl::ROLE_MANAGER);
         $editorRole = Role::findByName(Acl::ROLE_EDITOR);

--- a/database/seeds/DatabaseSeeder.php
+++ b/database/seeds/DatabaseSeeder.php
@@ -3,7 +3,7 @@
 use App\Laravue\Models\User;
 use Illuminate\Database\Seeder;
 use Illuminate\Support\Facades\Hash;
-use Spatie\Permission\Models\Role;
+use App\Laravue\Models\Role;
 
 class DatabaseSeeder extends Seeder
 {


### PR DESCRIPTION
#133 
- Use `api` gurad by default for Role/Permission models
- Correct class
