### PR TITLE
Implementing a generic API client

### DIFF
--- a/resources/js/api/generic.js
+++ b/resources/js/api/generic.js
@@ -3,42 +3,42 @@ import request from '@/utils/request';
 class GenericRequest{
   get(url, query) {
     return request({
-      url: url,
+      url: '/' + url,
       method: 'get',
       params: query,
     });
   }
   post(url, data) {
     return request({
-      url: url,
+      url: '/' + url,
       method: 'post',
       data: data,
     });
   }
   postWithId(url, id, data) {
     return request({
-      url: url + '/' + id,
+      url: '/' + url + '/' + id,
       method: 'post',
       data: data,
     });
   }
   put(url, data) {
     return request({
-      url: url,
+      url: '/' + url,
       method: 'put',
       data: data,
     });
   }
   putWithId(url, id, data) {
     return request({
-      url: url + '/' + id,
+      url: '/' + url + '/' + id,
       method: 'put',
       data: data,
     });
   }
-  delete(url, data) {
+  delete(url) {
     return request({
-      url: url,
+      url: '/' + url,
       method: 'delete',
     });
   }

--- a/resources/js/api/generic.js
+++ b/resources/js/api/generic.js
@@ -1,0 +1,46 @@
+import request from '@/utils/request';
+
+class GenericRequest{
+  get(url, query) {
+    return request({
+      url: url,
+      method: 'get',
+      params: query,
+    });
+  }
+  post(url, data) {
+    return request({
+      url: url,
+      method: 'post',
+      data: data,
+    });
+  }
+  postWithId(url, id, data) {
+    return request({
+      url: url + '/' + id,
+      method: 'post',
+      data: data,
+    });
+  }
+  put(url, data) {
+    return request({
+      url: url,
+      method: 'put',
+      data: data,
+    });
+  }
+  putWithId(url, id, data) {
+    return request({
+      url: url + '/' + id,
+      method: 'put',
+      data: data,
+    });
+  }
+  delete(url, data) {
+    return request({
+      url: url,
+      method: 'delete',
+    });
+  }
+}
+export { GenericRequest as default };


### PR DESCRIPTION
## What?
Generic API Client
## Why?
In order to access the non-resource API end-points, we can create a js file inside the API folder as a custom client.
using this file we can access endpoints directly by their URL and pass data.
## How?
Create an instance of GenericRequest then call one of the following methods:
- get(url, params) // HTTP GET Request
- post(url, data) // HTTP POST Request
- put(url, data) // HTTP PUT Request
- delete(url) // HTTP DELETE Request
- postWithId(url, id, data) // HTTP POST Request  "/url/id"
- putWithId(url,id,data) // HTTP PUT Request "/url/id"